### PR TITLE
update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ COPY --from=build-backend /venv /venv
 
 COPY backend/start.sh backend/manage.sh /
 RUN chmod +x /start.sh /manage.sh
-CMD ["/start.sh"]
+CMD ["/bin/sh", "-c", "[ -d /app-dist/1.0.189-nightly.2 ] || ./manage.sh add_version 1.0.189-nightly.2; ./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY backend/manage.py backend/gunicorn.conf.py ./
 COPY backend/tabby tabby
 COPY --from=frontend /app/build /frontend
 
-ARG BUNDLED_TABBY=1.0.187-nightly.1
+ARG BUNDLED_TABBY=1.0.189-nightly.2
 
 RUN FRONTEND_BUILD_DIR=/frontend /venv/*/bin/python ./manage.py collectstatic --noinput
 RUN APP_DIST_STORAGE=file:///app-dist /venv/*/bin/python ./manage.py add_version ${BUNDLED_TABBY}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 
 # Rust (for python-cryptography)
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH /root/.cargo/bin:$PATH
+ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN pip install -U setuptools cryptography==37.0.4 poetry==1.1.7
 COPY backend/pyproject.toml backend/poetry.lock ./
@@ -50,9 +50,9 @@ RUN APP_DIST_STORAGE=file:///app-dist /venv/*/bin/python ./manage.py add_version
 
 FROM python:3.7-alpine AS backend
 
-ENV APP_DIST_STORAGE file:///app-dist
-ENV DOCKERIZE_VERSION v0.6.1
-ENV DOCKERIZE_ARCH amd64
+ENV APP_DIST_STORAGE="file:///app-dist"
+ENV DOCKERIZE_VERSION="v0.6.1"
+ENV DOCKERIZE_ARCH="amd64"
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; \
     then export DOCKERIZE_ARCH=armhf; \

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This is the Tabby terminal, served as a web app. It also provides the config sync service for the Tabby app.
 
-You can use this to deploy your own copy or to make improvements - pull requests are welcome!
-
 # How it works
 
 Tabby Web serves the [Tabby Terminal](https://github.com/Eugeny/tabby) as a web application while managing multiple config files, authentication, and providing TCP connections via a [separate gateway service](https://github.com/Eugeny/tabby-connection-gateway).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Tabby Web
 
+## Note on project status
+
+> [!IMPORTANT]  
+> At this time I don't have the time to work on `tabby-web` and won't be able to provide help or support for it. I'm still happy to merge any fixes/improvement PRs. :v:
+
+
 ![](docs/screenshot.png)
 
 This is the Tabby terminal, served as a web app. It also provides the config sync service for the Tabby app.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Tabby Web
 
-> 👋 Tabby Web is looking for sponsors. As I can't afford to host it myself any longer, I'm looking for a sponsor to cover the hosting costs. If you're interested, please [get in touch](https://twitter.com/eugeeeeny)!
-
 ![](docs/screenshot.png)
 
-This is the exact code that runs at https://tabby.sh. In fact, it's being deployed straight out of this repository.
+This is the Tabby terminal, served as a web app. It also provides the config sync service for the Tabby app.
 
 You can use this to deploy your own copy or to make improvements - pull requests are welcome!
 

--- a/backend/tabby/app/management/commands/add_version.py
+++ b/backend/tabby/app/management/commands/add_version.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
 
                 with tempfile.NamedTemporaryFile("wb") as f:
                     f.write(response.content)
+                    f.flush()
                     plugin_final_target = Path(tempdir) / plugin
 
                     with tempfile.TemporaryDirectory() as extraction_tmp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
     tabby:
         build: .
         restart: always
-        command: /bin/sh -c "[ -d /app-dist/1.0.189-nightly.2 ] || ./manage.sh add_version 1.0.189-nightly.2; ./start.sh"
         volumes:
         - ./app-dist:/app-dist
         - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,16 @@ services:
     tabby:
         build: .
         restart: always
-        depends_on:
-        - db
+        command: /bin/sh -c "[ -d /app-dist/1.0.189-nightly.2 ] || ./manage.sh add_version 1.0.189-nightly.2; ./start.sh"
+        volumes:
+        - ./app-dist:/app-dist
+        - ./data:/data
         ports:
         - 9090:80
         environment:
-        - DATABASE_URL=mysql://root:123@db/tabby
+        - DATABASE_URL=sqlite:////data/db.sqlite3
         - PORT=80
         - DEBUG=False
-        - DOCKERIZE_ARGS="-wait tcp://db:3306 -timeout 60s"
+        - SOCIAL_AUTH_GITHUB_KEY=xxx
+        - SOCIAL_AUTH_GITHUB_SECRET=yyy
         # - APP_DIST_STORAGE="file:///app-dist"
-
-    db:
-        image: mariadb:10.7.1
-        restart: always
-        environment:
-            MARIADB_DATABASE: tabby
-            MARIADB_USER: user
-            MARIADB_PASSWORD: 123
-            MYSQL_ROOT_PASSWORD: 123


### PR DESCRIPTION
## Summary by Sourcery

Switch deployment to use embedded SQLite and persistent volumes, remove external MariaDB service, add GitHub auth env, automate version registration on startup, bump default bundled version, improve file handling in version command, and update README with project status note.

Enhancements:
- Use SQLite as the database backend with a local data volume
- Remove the MariaDB service from docker-compose and mount app-dist and data volumes
- Add SOCIAL_AUTH_GITHUB_KEY and SOCIAL_AUTH_GITHUB_SECRET environment variables
- Automate adding the bundled version on container startup if missing
- Bump BUNDLED_TABBY default version to 1.0.189-nightly.2
- Quote environment variable values in Dockerfile for consistency
- Flush temporary file after writing in add_version command

Documentation:
- Add a project status note to README and update the project description